### PR TITLE
Add gcp_name variable to allow multiple instances in a GCP Project

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -17,7 +17,7 @@ provider "google" {
 }
 
 resource "google_compute_instance" "kbn_vm" {
-  name         = "kbn-dev-vm"
+  name         = var.gcp_name
   machine_type = var.gcp_instance_type
 
   boot_disk {

--- a/gcp/network.tf
+++ b/gcp/network.tf
@@ -1,10 +1,10 @@
 resource "google_compute_network" "kbn_vpc" {
-  name                    = "kbn-vpc"
+  name                    =  "${var.gcp_name}-vpc"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "kbn_subnet" {
-  name          = "kbn-subnet"
+  name          = "${var.gcp_name}-subnet"
   ip_cidr_range = "10.0.0.0/24"
   network       = google_compute_network.kbn_vpc.id
 }

--- a/gcp/security.tf
+++ b/gcp/security.tf
@@ -1,5 +1,5 @@
 resource "google_compute_firewall" "kbn_firewall" {
-  name    = "kbn-firewall"
+  name    = "${var.gcp_name}-firewall"
   network = google_compute_network.kbn_vpc.name
 
   # allow tcp/ssh from anywhere

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -61,3 +61,9 @@ variable "gcp_vm_admin_username" {
   type        = string
   description = "Username for authenticating to the provisioned instance."
 }
+
+variable "gcp_name" {
+  default     = "kbn-dev-vm"
+  type        = string
+  description = "GCP instance name"
+}


### PR DESCRIPTION
This PR is adding a new variable to gcp, `gcp_name`. This change allows multiple instances in 1 google cloud project using a different name (that's also used to prefix e.g. network names).