### PR TITLE
Fix deployment of git tags of the Kibana repo

### DIFF
--- a/gcp/kbn-dev.sh
+++ b/gcp/kbn-dev.sh
@@ -23,7 +23,7 @@ if [[ $TYPE && $TYPE == "pr" ]]; then
   REPO_URL=$( jq -r  '.head.repo.html_url' <<< "${content}" )
   BRANCH=$( jq -r  '.head.ref' <<< "${content}" )
 elif [[  $TYPE && $TYPE == "tag" ]]; then
-  BRANCH="tags/${VALUE} -b tags-${VALUE}"
+  BRANCH="${VALUE}"
   GCP_NAME="${GCP_NAME_PREFIX}-${TYPE}-${VALUE//./-}"
 elif [[  $TYPE && $TYPE == "branch" ]]; then
   BRANCH="${VALUE}"


### PR DESCRIPTION
Due to the switch to flat cloning in #7 , deployment of tags of the Kibana repo no longer worked. With this PR it works again:

Testing: `./kbn-dev.sh deploy tag v7.14.0`
`