### PR TITLE
Add password flag to deploy action

### DIFF
--- a/gcp/.terraform.lock.hcl
+++ b/gcp/.terraform.lock.hcl
@@ -18,3 +18,21 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f6a43e7251b3d1fad1958be7ecb99542357648da87f5f0d93f08ac5f4378736a",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -26,9 +26,9 @@ it's also removed from the list.
 
 ### Basic usage
 
-Deploy a PR in
+Deploy a PR (if you don't set a password, its generated automatically)
 
-`./kbn-dev.sh deploy pr {numberOfPR}`
+`./kbn-dev.sh deploy pr {numberOfPR} --password={elasticUserLoginPWtoSet}` 
 
 Update the instance of a PR
 

--- a/gcp/kbn-dev.sh
+++ b/gcp/kbn-dev.sh
@@ -99,7 +99,7 @@ case $ACTION in
     PUBLIC_IP=$(terraform -chdir="${SCRIPT_DIR}" output -json | jq  -r '.public_ip.value')
     KIBANA_URL=$(terraform -chdir="${SCRIPT_DIR}" output -json | jq  -r '.kibana_url.value')
     KIBANA_SERVER_PASSWORD=$(terraform -chdir="${SCRIPT_DIR}" output -json | jq  -r '.kibana_elastic_password.value')
-    log "🥬 Password ${KIBANA_SERVER_PASSWORD}"
+    [ -z "$PASSWORD" ] && log "🥥 Generated Password ${KIBANA_SERVER_PASSWORD}"
 
     if [[ $KIBANA_URL != 'null' ]];
       then

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -19,7 +19,7 @@ provider "google" {
 resource "random_password" "password" {
   length           = 32
   special          = true
-  override_special = "_%@"
+  override_special = "_-!@"
 }
 
 locals {

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -16,6 +16,16 @@ provider "google" {
   credentials = file(var.gcp_credentials_file)
 }
 
+resource "random_password" "password" {
+  length           = 32
+  special          = true
+  override_special = "_%@"
+}
+
+locals {
+  kibana_used_elastic_password = coalesce(var.kibana_server_password, random_password.password.result)
+}
+
 resource "google_compute_instance" "kbn_vm" {
   name         = var.gcp_name
   machine_type = var.gcp_instance_type
@@ -55,7 +65,6 @@ resource "google_compute_instance" "kbn_vm" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/*.sh",
-      "/tmp/install.sh ${var.kibana_repo_url} ${var.kibana_repo_branch}",
     ]
   }
 

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -7,6 +7,12 @@ output "kibana_url" {
   description = "Please allow a few minutes for the Kibana server to start and the optimizer to run."
 }
 
+output "kibana_elastic_password" {
+  value       = local.kibana_used_elastic_password
+  description = "Password of elastic user"
+  sensitive = true
+}
+
 output "ssh_access" {
   value = "ssh ${var.gcp_vm_admin_username}@${google_compute_instance.kbn_vm.network_interface.0.access_config.0.nat_ip}"
 }

--- a/gcp/scripts/elasticsearch.service
+++ b/gcp/scripts/elasticsearch.service
@@ -3,7 +3,7 @@ Description=Kibana dev service
 [Service]
 User=ubuntu
 Group=ubuntu
-ExecStart=/usr/local/bin/node  /home/ubuntu/kibana/scripts/es snapshot -E path.data=/home/ubuntu/data
+ExecStart=/usr/local/bin/node  /home/ubuntu/kibana/scripts/es snapshot -E path.data=/home/ubuntu/data {PASSWORD}
 
 [Install]
 WantedBy=multi-user.target

--- a/gcp/scripts/install.sh
+++ b/gcp/scripts/install.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
 set -ex
 
-# this script takes two arguments: $1=repo to clone, $2=branch to checkout
+# this script takes 3 arguments: $1=repo to clone, $2=branch to checkout, $3=PASSWORD of the elastic user
 REPO=$1
 BRANCH=$2
+PASSWORD=$3
 
 # need to increase this value to run Kibana in dev mode
 sudo sysctl -w fs.inotify.max_user_watches=524288
 
-# clone kibana repo, check out branch, and configure environment
+[[ $PASSWORD != "changeme" ]] && PASSWORD_REPLACE="--password=${PASSWORD}" || PASSWORD_REPLACE=""
+
+# Adaptions and deployment of systemd services
+sudo sed -e "s/{PASSWORD}/${PASSWORD_REPLACE}/g" /tmp/elasticsearch.service > /tmp/elasticsearch.edited.service
+sudo cp /tmp/elasticsearch.edited.service  /lib/systemd/system/elasticsearch.service
+sudo cp /tmp/kibana.service  /lib/systemd/system/kibana.service
+sudo systemctl daemon-reload
+
+# Clone kibana repo, check out branch, and configure environment
 git clone --branch "${BRANCH}" --single-branch --depth 1 "${REPO}.git" kibana
 sudo touch /var/log/kibana.log
 sudo chown ubuntu /var/log/kibana.log
 
-sudo cp /tmp/kibana.service  /lib/systemd/system/
-sudo cp /tmp/elasticsearch.service  /lib/systemd/system/
-sudo systemctl daemon-reload
+# Configuration of Kibana
+cp kibana/config/kibana.yml kibana/config/kibana.dev.yml
+[[ $PASSWORD != "changeme" ]] && echo -e "\nelasticsearch.password: \"${PASSWORD}\"" >> kibana/config/kibana.dev.yml
+
+

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -5,6 +5,7 @@
 kibana_repo_url = "https://github.com/elastic/kibana"
 kibana_repo_branch = "master"
 kibana_server_port = 5601
+kibana_server_password = "changeme"
 
 public_key_path = "~/.ssh/id_rsa.pub"
 private_key_path = "~/.ssh/id_rsa"

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -16,6 +16,12 @@ variable "kibana_server_port" {
   description = "Kibana's dev server port (5601 unless you have explicitly changed it in `kibana.dev.yml`)."
 }
 
+variable "kibana_server_password" {
+  default     = "changeme"
+  type        = string
+  description = "Password for elastic user."
+}
+
 variable "public_key_path" {
   default     = "~/.ssh/id_rsa.pub"
   type        = string


### PR DESCRIPTION
This PR adds a `password` flag used when deploying an instance: 

`./kbn-dev.sh (deploy|destroy|update|status|ssh) (branch|tag|pr) (nameOfBranchOrTagOrPR)" --password={password}`

If the password is not provided, a random password is generated and used. It's displayed in the CLI, and if forgotten, it can be retrieved by e.g.

`./kbn-dev.sh status (branch|tag|pr) (nameOfBranchOrTagOrPR)`

This PR fixes the issue when setting a custom password in Kibana UI, updating the instance with `a-la-carte`, the password for the `elastic` user was always reset to `changeme`.

It's of course not best practice to store passwords in state like terraform, however we're dealing with dev instances here, and this passwords needs to be set every time `yarn es snapshot` is called, so the first goal of this PR is to enable other passwords then `changeme` in an easy way.

Note that there's no automatic password change after deployment supported.
